### PR TITLE
Update radar controller code to remove unnecessary CAN messages.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-can>=2.1.0
+python-can==2.1.0
 bidict>=0.17.2
 netifaces>=0.10.7
 cantools==22.0.0

--- a/ros1_bridge/build.sh
+++ b/ros1_bridge/build.sh
@@ -1,7 +1,4 @@
-source $ROS1_ROOT/setup.bash
-. $ROS2_ROOT/install/local_setup.bash
-source ../ros1_ws/devel/setup.bash
-. ../ros2_ws/install/local_setup.bash
+source ./source.sh
 cd $ROS2_ROOT
 rm -rf build/ros1_bridge
 colcon build --symlink-install --packages-select ros1_bridge --cmake-force-configure

--- a/ros1_bridge/source.sh
+++ b/ros1_bridge/source.sh
@@ -1,0 +1,4 @@
+source $ROS1_ROOT/setup.bash
+. $ROS2_ROOT/install/local_setup.bash
+source ../ros1_ws/devel/setup.bash
+. ../ros2_ws/install/local_setup.bash

--- a/ros1_ws/src/launch/zed_libav_video_record_left.launch
+++ b/ros1_ws/src/launch/zed_libav_video_record_left.launch
@@ -12,7 +12,8 @@
 -->
 <launch>
 
-  <arg name="record_root" />
+  <arg name="record_root" default="$(dirname)/../../../data/"/>
+  <arg name="record_rosbag" default="1"/>
 
   <param name="libav_video_encoder_root_path" value="$(arg record_root)" />
   <param name="libav_video_encoder_codec" value="libx265" />
@@ -40,6 +41,6 @@
     <param name="libav_capture_device" value="/dev/video0" />
   </node>
 
-  <node pkg="rosbag" type="record" name="rosbag_record_rgb" args="-o $(arg record_root)/rosbag zed/rgb/image_raw_color/stream zed/rgb/image_raw_color/stream/event "/>
+  <node pkg="rosbag" type="record" name="rosbag_record_rgb" args="-o $(arg record_root)/rosbag zed/rgb/image_raw_color/stream zed/rgb/image_raw_color/stream/event radar_tracks can_recv can_send" if="$(arg record_rosbag)"/>
 
 </launch>

--- a/ros1_ws/src/radar/package.xml
+++ b/ros1_ws/src/radar/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>radar</name>
+  <version>0.0.1</version>
+  <description>Toyota Radar controller</description>
+  <maintainer email="farazrkhan@gmail.com">Faraz Khan</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>rosconsole</depend>
+  <depend>sensor_msgs</depend>
+  <depend>opencv3</depend>
+  <depend>image_transport</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>pcl_conversions</depend>
+  <depend>nodelet</depend>
+
+</package>

--- a/ros1_ws/src/radar/src/radar_viz.py
+++ b/ros1_ws/src/radar/src/radar_viz.py
@@ -1,0 +1,1 @@
+../../../../ros2_ws/src/radar/radar/radar_viz.py

--- a/ros1_ws/src/util/package.xml
+++ b/ros1_ws/src/util/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>util</name>
+  <version>0.0.1</version>
+  <description>OpenCaret Utilities</description>
+  <maintainer email="farazrkhan@gmail.com">Faraz Khan</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>rosconsole</depend>
+  <depend>sensor_msgs</depend>
+  <depend>opencv3</depend>
+  <depend>image_transport</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>pcl_conversions</depend>
+  <depend>nodelet</depend>
+
+</package>

--- a/ros1_ws/src/util/setup.py
+++ b/ros1_ws/src/util/setup.py
@@ -1,0 +1,11 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['util'],
+    package_dir={'': 'src'}
+)
+
+setup(**setup_args)

--- a/ros1_ws/src/util/src/util/rospy_compat.py
+++ b/ros1_ws/src/util/src/util/rospy_compat.py
@@ -1,0 +1,1 @@
+../../../../../ros2_ws/src/util/util/rospy_compat.py

--- a/ros2_ws/src/opencaret_msgs/msg/RadarTrack.msg
+++ b/ros2_ws/src/opencaret_msgs/msg/RadarTrack.msg
@@ -4,4 +4,5 @@ float32 lat_dist
 float32 lng_dist
 bool new_track
 float32 rel_speed
+int8 valid_count
 bool valid

--- a/ros2_ws/src/radar/radar/radar_viz.py
+++ b/ros2_ws/src/radar/radar/radar_viz.py
@@ -7,7 +7,9 @@ from std_msgs.msg import ColorRGBA
 
 class RadarViz(rospy_compat.Node):
     def __init__(self):
-        rospy.init_node('radar_viz', log_level=rospy.INFO)
+        if not(rospy_compat.use_ros_1):
+            super().__init__('radar_viz')
+        rospy_compat.init_node(self, 'radar_viz')
         self.radar_sub = rospy_compat.Subscriber('/radar_tracks', RadarTracks, self.on_radar_tracks)
         self.radar_rviz_pub = rospy_compat.Publisher('/radar_viz', Marker, queue_size=1)
 
@@ -15,7 +17,7 @@ class RadarViz(rospy_compat.Node):
         marker = Marker()
         marker.header.frame_id = "middle_radar_link"
         if rospy_compat.use_ros_1:
-            marker.header.stamp = rospy.Time.now()
+            marker.header.stamp = rospy_compat.rospy.Time.now()
         marker.ns = "radar_tracks"
         marker.id = 1
         marker.type = Marker.POINTS

--- a/ros2_ws/src/util/util/rospy_compat.py
+++ b/ros2_ws/src/util/util/rospy_compat.py
@@ -6,6 +6,7 @@ YMMV will vary as this is not intended for 100% compatibility.
 use_ros_1=False
 try:
     import rclpy
+    from util import util
     from rclpy.node import Node
 except:
     pass
@@ -16,7 +17,7 @@ try:
 except:
     pass
 
-global node
+node = None
 
 if use_ros_1:
     from rospy import Subscriber, Publisher
@@ -24,21 +25,23 @@ else:
     class Subscriber(object):
 
         def __init__(self, topic, type, func, queue_size=0):
-            self.sub = node.create_subscription(type, topic, func, queue_size=queue_size)
+            global node
+            self.sub = node.create_subscription(type, topic, func)
 
     class Publisher(object):
 
-        def __init__(self, topic, type, func, queue_size=0):
-            self.pub = node.create_publisher(type, topic, func, queue_size=queue_size)
+        def __init__(self, topic, type, queue_size=0):
+            global node
+            self.pub = node.create_publisher(type, topic)
 
         def publish(self, msg):
             self.pub.publish(msg)
 
-def init_node(node, name, log_level=rospy.INFO):
+def init_node(node_obj, name, log_level=None):
+    global node
+    node = node_obj
     if use_ros_1:
         rospy.init_node(name, log_level=log_level)
-    else:
-        node.__init__(name)
 
 def launch_node(type):
     global node
@@ -48,6 +51,6 @@ def launch_node(type):
     else:
         rclpy.init()
         node = type()
-        rclpy.spin(radar)
+        rclpy.spin(node)
         node.destroy_node()
         rclpy.shutdown()

--- a/ros2_ws/src/util/util/rospy_compat.py
+++ b/ros2_ws/src/util/util/rospy_compat.py
@@ -1,0 +1,53 @@
+"""
+This utility provides a compatibility layer between ROS 1 and 2.
+YMMV will vary as this is not intended for 100% compatibility.
+"""
+
+use_ros_1=False
+try:
+    import rclpy
+    from rclpy.node import Node
+except:
+    pass
+try:
+    import rospy
+    Node=object
+    use_ros_1=True
+except:
+    pass
+
+global node
+
+if use_ros_1:
+    from rospy import Subscriber, Publisher
+else:
+    class Subscriber(object):
+
+        def __init__(self, topic, type, func, queue_size=0):
+            self.sub = node.create_subscription(type, topic, func, queue_size=queue_size)
+
+    class Publisher(object):
+
+        def __init__(self, topic, type, func, queue_size=0):
+            self.pub = node.create_publisher(type, topic, func, queue_size=queue_size)
+
+        def publish(self, msg):
+            self.pub.publish(msg)
+
+def init_node(node, name, log_level=rospy.INFO):
+    if use_ros_1:
+        rospy.init_node(name, log_level=log_level)
+    else:
+        node.__init__(name)
+
+def launch_node(type):
+    global node
+    if use_ros_1:
+        node = type()
+        rospy.spin()
+    else:
+        rclpy.init()
+        node = type()
+        rclpy.spin(radar)
+        node.destroy_node()
+        rclpy.shutdown()


### PR DESCRIPTION
Update radar controller to introduce a valid count for each radar track. Both valid and invalid tracks are published.
Update radar viz to show both valid/invalid tracks with different colors.
Refactor radar_viz code to work in both ROS1 and ROS2.
Introduce ROS 1/2 compatibility utility.
Modify requirements to peg python-can to 2.1.0 (experienced strange warnings and behavior with latest version)