### PR TITLE
Jose/ros1 launch playback

### DIFF
--- a/ros1_ws/src/launch/zed_libav_video_record_left.launch
+++ b/ros1_ws/src/launch/zed_libav_video_record_left.launch
@@ -13,7 +13,6 @@
 <launch>
 
   <arg name="record_root" default="$(dirname)/../../../data/"/>
-  <arg name="record_rosbag" default="1"/>
 
   <param name="libav_video_encoder_root_path" value="$(arg record_root)" />
   <param name="libav_video_encoder_codec" value="libx265" />
@@ -22,11 +21,11 @@
   <param name="libav_video_encoder_framerate" value="10" />
   <param name="libav_capture_video_size" value="3840x1080" />
 
-  <node pkg="ros_libav" type="record.py" name="libav_video_recorder_left" >
+  <node pkg="ros_libav" type="record.py" name="libav_video_recorder_left" clear_params="true" >
     <param name="libav_video_encoder_image_filetype" value="mpg" />
-    <param name="libav_video_encoder_image_topic" value="zed/rgb/image_raw_color" />
-    <param name="libav_video_encoder_stream_topic" value="zed/rgb/image_raw_color/stream" />
-    <param name="libav_video_encoder_stream_event_topic" value="zed/rgb/image_raw_color/stream/event" />
+    <param name="libav_video_encoder_image_topic" value="zed/left/image_raw_color" />
+    <param name="libav_video_encoder_stream_topic" value="zed/left/image_raw_color/stream" />
+    <param name="libav_video_encoder_stream_event_topic" value="zed/left/image_raw_color/stream/event" />
     <param name="libav_video_encoder_delay" value="0.5" />
     <param name="libav_video_encoder_finalize_delay" value="0.75" />
     <param name="libav_video_encoder_video_size" value="1920x1080" />
@@ -36,11 +35,9 @@
   </node>
 
   <node pkg="ros_libav" type="capture.py" name="libav_capture" >
-    <param name="libav_capture_image_topic" value="zed/rgb/image_raw_color" />
+    <param name="libav_capture_image_topic" value="zed/left/image_raw_color" />
     <param name="libav_capture_format" value="video4linux2" />
     <param name="libav_capture_device" value="/dev/video1" />
   </node>
-
-  <node pkg="rosbag" type="record" name="rosbag_record_rgb" args="-o $(arg record_root)/rosbag zed/rgb/image_raw_color/stream zed/rgb/image_raw_color/stream/event radar_tracks can_recv can_send" if="$(arg record_rosbag)"/>
 
 </launch>

--- a/ros1_ws/src/launch/zed_video_playback.launch
+++ b/ros1_ws/src/launch/zed_video_playback.launch
@@ -2,7 +2,7 @@
 @Author: Jose Rojas <jrojas>
 @Date:   2018-07-12T01:43:12-07:00
 @Email:  jrojas@redlinesolutions.co
-@Project: ros-libav-node
+@Project: opencaret
 @Last modified by:   jrojas
 @Last modified time: 2018-07-14T09:13:21-07:00
 @License: MIT License
@@ -11,9 +11,8 @@
 
 <launch>
 
-    <arg name="record_root"/>
-    <arg name="bagfile" />
-
+    <arg name="record_root" default="$(dirname)/../../../data/"/>
+    
     <param name="libav_video_decoder_root_path" value="$(arg record_root)" />
 
     <node pkg="ros_libav" type="playback.py" name="libav_video_player" >
@@ -30,6 +29,4 @@
       <param name="libav_video_decoder_stream_topic" value="zed/right/image_raw_color/stream" />
       <param name="libav_video_decoder_stream_event_topic" value="zed/right/image_raw_color/stream/event" />
     </node>
-
-    <node pkg="rosbag" type="play" name="rosbag_player_rgb" args="-l -d 2 $(arg bagfile)"/>
 </launch>

--- a/ros1_ws/src/launch/zed_wrapper_video_record_left.launch
+++ b/ros1_ws/src/launch/zed_wrapper_video_record_left.launch
@@ -12,30 +12,26 @@
 -->
 <launch>
 
-  <arg name="record_root" />
+  <arg name="record_root" default="$(dirname)/../../../data/"/>
 
   <param name="libav_video_encoder_root_path" value="$(arg record_root)" />
   <param name="libav_video_encoder_codec" value="libx265" />
   <param name="libav_video_encoder_preset" value="ultrafast" />
   <param name="libav_video_encoder_level" value="17" />
   <param name="libav_video_encoder_framerate" value="10" />
-  <param name="libav_capture_video_size" value="3840x1080" />
+  <param name="libav_capture_video_size" value="1920x1080" />
 
-  <node pkg="ros_libav" type="record.py" name="libav_video_recorder_left" >
+  <node pkg="ros_libav" type="record.py" name="libav_video_recorder_left" clear_params="true">
     <param name="libav_video_encoder_image_filetype" value="mpg" />
-    <param name="libav_video_encoder_image_topic" value="zed/rgb/image_raw_color" />
-    <param name="libav_video_encoder_stream_topic" value="zed/rgb/image_raw_color/stream" />
-    <param name="libav_video_encoder_stream_event_topic" value="zed/rgb/image_raw_color/stream/event" />
+    <param name="libav_video_encoder_image_topic" value="zed/left/image_raw_color" />
+    <param name="libav_video_encoder_stream_topic" value="zed/left/image_raw_color/stream" />
+    <param name="libav_video_encoder_stream_event_topic" value="zed/left/image_raw_color/stream/event" />
     <param name="libav_video_encoder_delay" value="0.5" />
     <param name="libav_video_encoder_finalize_delay" value="0.75" />
-    <param name="libav_video_encoder_video_size" value="960x540" />
+    <param name="libav_video_encoder_video_size" value="1920x1080" />
     <!--<param name="libav_video_encoder_crop" value="1920:1080:0:0" />-->
-    <param name="libav_video_encoder_flip_v" value="1" />
-    <param name="libav_video_encoder_flip_h" value="1" />
+    <param name="libav_video_encoder_flip_v" value="0" />
+    <param name="libav_video_encoder_flip_h" value="0" />
   </node>
-
-  <include file="$(find zed_wrapper)/launch/display.launch" />
-
-  <node pkg="rosbag" type="record" name="rosbag_record_rgb" args="-o $(arg record_root)/rosbag zed/rgb/image_raw_color/stream zed/rgb/image_raw_color/stream/event "/>
 
 </launch>

--- a/ros1_ws/src/util/src/util/abs_path.py
+++ b/ros1_ws/src/util/src/util/abs_path.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+import sys
+import os.path
+import glob
+
+def main():
+    print(os.path.abspath(sys.argv[1]))
+
+if __name__ == '__main__':
+    main()

--- a/ros1_ws/src/util/src/util/latest_file.py
+++ b/ros1_ws/src/util/src/util/latest_file.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+import sys
+import os.path
+import glob
+
+def latest_file_in_glob_path(path):
+    list_of_files = glob.glob(path)
+    latest_file = max(list_of_files, key=os.path.getctime)
+    return latest_file
+
+def main():
+    print(os.path.abspath(latest_file_in_glob_path(sys.argv[1] + "/*")))
+
+if __name__ == '__main__':
+    main()

--- a/ros1_ws/src/util/src/util/latest_file.py
+++ b/ros1_ws/src/util/src/util/latest_file.py
@@ -9,7 +9,7 @@ def latest_file_in_glob_path(path):
     return latest_file
 
 def main():
-    print(os.path.abspath(latest_file_in_glob_path(sys.argv[1] + "/*")))
+    print(os.path.abspath(latest_file_in_glob_path(sys.argv[1])))
 
 if __name__ == '__main__':
     main()

--- a/scripts/play_bag.sh
+++ b/scripts/play_bag.sh
@@ -1,0 +1,12 @@
+bagfile=$1
+cwd=$(dirname "$0")
+
+if [ "$bagfile" == '' ]; then
+  # use the latest
+  bagfile=$($cwd/../ros1_ws/src/util/src/util/latest_file.py $cwd/../data)
+else
+  # absolute
+  bagfile=$($cwd/../ros1_ws/src/util/src/util/abs_path.py $bagfile)
+fi
+
+rosbag play -l -d 2 $bagfile

--- a/scripts/play_bag.sh
+++ b/scripts/play_bag.sh
@@ -3,7 +3,7 @@ cwd=$(dirname "$0")
 
 if [ "$bagfile" == '' ]; then
   # use the latest
-  bagfile=$($cwd/../ros1_ws/src/util/src/util/latest_file.py $cwd/../data)
+  bagfile=$($cwd/../ros1_ws/src/util/src/util/latest_file.py $cwd/../data/'*.bag')
 else
   # absolute
   bagfile=$($cwd/../ros1_ws/src/util/src/util/abs_path.py $bagfile)

--- a/scripts/record_bag.sh
+++ b/scripts/record_bag.sh
@@ -1,3 +1,13 @@
+USE_CAMERA=1
+
+if [ "$USE_CAMERA" == "1" ]; then
+  VIDEO_TOPIC1="/zed/left/image_raw_color/stream"
+  VIDEO_TOPIC2="/zed/left/image_raw_color/stream/event"
+else
+  VIDEO_TOPIC1=""
+  VIDEO_TOPIC2=""
+fi
+
 rosbag record \
 /can_recv \
 /can_send \
@@ -25,7 +35,9 @@ rosbag record \
 /steering_angle \
 /steering_torque \
 /throttle_command \
-/wheel_speed
+/wheel_speed \
+$VIDEO_TOPIC1 \
+$VIDEO_TOPIC2
 #/zed/joint_states \
 #/zed/left/image_rect_color \
 #/zed/left/image_rect_color/camera_info \

--- a/scripts/record_bag_libav.sh
+++ b/scripts/record_bag_libav.sh
@@ -1,12 +1,5 @@
-USE_ZED_NODE=1
-
-if [ "$USE_ZED_NODE" == "1" ]; then
-  VIDEO_TOPIC1="/zed/rgb/image_rect_color/stream"
-  VIDEO_TOPIC2="/zed/rgb/image_rect_color/stream/event"
-else
-  VIDEO_TOPIC1="/zed/rgb/image_raw_color/stream"
-  VIDEO_TOPIC2="/zed/rgb/image_raw_color/stream/event"
-fi
+VIDEO_TOPIC1="/zed/left/image_raw_color/stream"
+VIDEO_TOPIC2="/zed/left/image_raw_color/stream/event"
 
 rosbag record \
 /can_recv \


### PR DESCRIPTION
Rosbag record and playback have been removed from launch files and placed into bash scripts.

The playback script allows for relative rosbag paths as the first argument. If the argument is missing, the most recent bagfile in the data folder is used.

Camera capture and recording launch files have been updated with normalized topic paths and parameters to capture the ZED camera FHD resolution.